### PR TITLE
update: #46 タスクを新規作成後リストデータをrefetchする

### DIFF
--- a/frontend/src/_components/features/Todo/add-area/index.tsx
+++ b/frontend/src/_components/features/Todo/add-area/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
+import { useFetchTodoList } from '@/hooks/use-fetch-todo-list'
 import { usePostCreateTodo } from '@/hooks/use-post-create-todo'
 import { authUserAtom } from '@/store'
 import { TodoCreateRequest } from '@/types/todo'
-import { Alert } from '@/_components/common/alert'
 import { Button } from '@/_components/common/button'
 import { InputField } from '@/_components/common/input-field'
 import { Box } from '@mui/material'
@@ -12,11 +12,12 @@ import { useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 export const TodoAddArea = () => {
+  const { refetch } = useFetchTodoList()
   const { doPost } = usePostCreateTodo()
   const authUser = useAtomValue(authUserAtom)
   const [isCreateLoading, setIsCreateLoading] = useState(false)
   const submitProcessing = useRef(false)
-  const { control, handleSubmit } = useForm<TodoCreateRequest>({
+  const { control, handleSubmit, reset } = useForm<TodoCreateRequest>({
     defaultValues: {
       title: '',
       detail: '',
@@ -38,10 +39,11 @@ export const TodoAddArea = () => {
     doPost({
       data: postData,
       onSuccess: () => {
-        return <Alert severity={'success'} text={'作成に成功しました'} />
+        refetch()
+        reset()
       },
       onError: () => {
-        return <Alert severity={'error'} text={'作成に失敗しました'} />
+        throw new Error('作成できませんでした')
       },
       onFinally: () => {
         submitProcessing.current = false


### PR DESCRIPTION
## レビュイー確認事項
- [x] Issue番号を記載

## 関連するIssue
<!-- 関連するIssue番号を記述します。 -->
close #46 

## 変更内容
<!-- 変更内容の概要を簡潔に説明してください。 -->
- タスクが本当に新規作成されたのか視覚的にわかるようにするために、新規作成後はリストデータをrefetchする

## Approve条件
<!-- ここにプルリクエストの概要を書きます。 -->
- 新規作成されたタスクが表示されていること

## スクリーンショット（もしあれば）

| before | after |
| --- | --- |
|  |  |

## 備考・補足事項
新規作成時の成功・失敗に関するトーストはUI上特に必要ないと感じたため削除しました。
エラー時のトーストを表示する代わりにエラーをスローするように変更しました。